### PR TITLE
SCMOD-11835: Fixed java security file patch failure

### DIFF
--- a/src/main/docker/disableWeakTlsAlgorithms.patch
+++ b/src/main/docker/disableWeakTlsAlgorithms.patch
@@ -20,8 +20,10 @@
  # Example:
  #   jdk.tls.disabledAlgorithms=MD5, SSLv3, DSA, RSA keySize < 2048
  jdk.tls.disabledAlgorithms=SSLv3, RC4, DES, MD5withRSA, DH keySize < 1024, \
--    EC keySize < 224, 3DES_EDE_CBC, anon, NULL
+-    EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
+-    include jdk.disabled.namedCurves
 +    EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
++    include jdk.disabled.namedCurves
 +    CAMELLIA_128_CBC, AES_256_CBC, AES_128_CBC, \
 +    DES40_CBC, RC4_40, CAMELLIA_256_CBC, DES_CBC, \
 +    SEED_CBC, RC4_56, RC4_128, IDEA_CBC, RC2_CBC_40, \


### PR DESCRIPTION
I have also tested this new build in the Tag Service and ran the testssh utility against it both before and after and you can see the results attached. If you compare the reports there is no change to the protocols offered.
[SCMOD-11835-after.txt](https://github.com/CAFapi/opensuse-java11-images/files/5636065/SCMOD-11835-after.txt)
[SCMOD-11835-before.txt](https://github.com/CAFapi/opensuse-java11-images/files/5636066/SCMOD-11835-before.txt)

