### PR TITLE
SCMOD-13716 Changes to patch file for disabling weak algorithms as a side effect of rpm version change.

### DIFF
--- a/src/main/docker/disableWeakTlsAlgorithms.patch
+++ b/src/main/docker/disableWeakTlsAlgorithms.patch
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
---- java.security-2.12	2021-05-11 14:42:38.000000000 +0530
-+++ java.security	2021-05-24 13:05:41.868287681 +0530
+--- java.security
++++ java.security
 @@ -739,6 +739,26 @@
  #   jdk.tls.disabledAlgorithms=MD5, SSLv3, DSA, RSA keySize < 2048
  jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, RC4, DES, MD5withRSA, \

--- a/src/main/docker/disableWeakTlsAlgorithms.patch
+++ b/src/main/docker/disableWeakTlsAlgorithms.patch
@@ -14,20 +14,15 @@
 # limitations under the License.
 #
 
---- java.security
-+++ java.security
-@@ -624,7 +624,29 @@
- # Example:
+--- java.security-2.12	2021-05-11 14:42:38.000000000 +0530
++++ java.security	2021-05-24 13:05:41.868287681 +0530
+@@ -739,6 +739,26 @@
  #   jdk.tls.disabledAlgorithms=MD5, SSLv3, DSA, RSA keySize < 2048
- jdk.tls.disabledAlgorithms=SSLv3, RC4, DES, MD5withRSA, DH keySize < 1024, \
--    EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
--    include jdk.disabled.namedCurves
-+    EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
+ jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, RC4, DES, MD5withRSA, \
+     DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
 +    CAMELLIA_128_CBC, AES_256_CBC, AES_128_CBC, \
 +    DES40_CBC, RC4_40, CAMELLIA_256_CBC, DES_CBC, \
 +    SEED_CBC, RC4_56, RC4_128, IDEA_CBC, RC2_CBC_40, \
-+    TLSv1, \
-+    TLSv1.1, \
 +    TLS_DH_DSS_WITH_AES_128_GCM_SHA256, \
 +    TLS_DH_DSS_WITH_AES_256_GCM_SHA384, \
 +    TLS_DH_RSA_WITH_AES_128_GCM_SHA256, \
@@ -45,7 +40,6 @@
 +    TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256, \
 +    TLS_DHE_DSS_WITH_AES_128_GCM_SHA256, \
 +    TLS_EMPTY_RENEGOTIATION_INFO_SCSV, \
-+    include jdk.disabled.namedCurves
-
- # Legacy algorithms for Secure Socket Layer/Transport Layer Security (SSL/TLS)
- # processing in JSSE implementation.
+     include jdk.disabled.namedCurves
+ 
+ #


### PR DESCRIPTION
Updated the patch to be able to update java.security file installed as part of java-11-openjdk-11.0.11.0-lp152.2.12.1.x86_64.rpm

The patch has been generated by adding the desired change to java.security file and then generating the patch file with diff command.

